### PR TITLE
Fix integer RNG in Random Number node

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -12538,7 +12538,7 @@ class WAS_Random_Number:
         # Return random number
         if number_type:
             if number_type == 'integer':
-                number = random.randint(minimum, maximum)
+                number = random.randint(round(minimum), round(maximum))
             elif number_type == 'float':
                 number = random.uniform(minimum, maximum)
             elif number_type == 'bool':


### PR DESCRIPTION
The input for min/max demands floats, but the base `random.randint` will complain if float types are passed to it.

Really, it would be nice to convert the input types for min/max to `NUMBER`, but I'm not sure how backwards-compatible that is with existing nodes.