### PR TITLE
fix: Correct TypeError in Random Number node

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -12538,7 +12538,7 @@ class WAS_Random_Number:
         # Return random number
         if number_type:
             if number_type == 'integer':
-                number = random.randint(minimum, maximum)
+                number = random.randint(int(minimum), int(maximum))
             elif number_type == 'float':
                 number = random.uniform(minimum, maximum)
             elif number_type == 'bool':
@@ -14879,3 +14879,4 @@ if show_quotes:
         '\033[93m"Every strike brings me closer to the next home run."\033[0m\033[3m - Babe Ruth',
     ]
     print(f'\n\t\033[3m{random.choice(art_quotes)}\033[0m\n')
+


### PR DESCRIPTION
**Description:**
This PR fixes a small bug in the WAS_Random_Number node.

**The Problem:**
When the number_type is set to 'integer', the node throws a TypeError: 'float' object cannot be interpreted as an integer. This happens because the minimum and maximum float inputs are passed directly to random.randint(), which requires integer arguments.

**The Solution:**
This change simply casts the minimum and maximum variables to int() before they are passed to the function, resolving the error. The node now functions correctly in integer mode. Thanks for all your work on this suite!