### PR TITLE
Disabled the inspirational startup quote by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ cache/
 *.latent
 *.image
 *.conditioning
+/nbproject/

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -208,7 +208,7 @@ was_conf_template = {
                     "run_requirements": True,
                     "suppress_uncomfy_warnings": True,
                     "show_startup_junk": True,
-                    "show_inspiration_quote": True,
+                    "show_inspiration_quote": False,
                     "text_nodes_type": "STRING",
                     "webui_styles": None,
                     "webui_styles_persistent_update": True,


### PR DESCRIPTION
This PR disables the inspirational startup quote by default.

The console log during initialization is primarily a diagnostic channel, and unconditional non-actionable output increases noise without adding functional value.

The feature remains fully configurable via show_inspiration_quote for users who wish to enable it.