### PR TITLE
Fix Save Text File relative path handling (anchor to ComfyUI output dir)

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -10845,10 +10845,14 @@ class WAS_Text_Save:
     FUNCTION = "save_text_file"
     CATEGORY = "WAS Suite/IO"
 
-    def save_text_file(self, text, path, filename_prefix='ComfyUI', filename_delimiter='_', 
+    def save_text_file(self, text, path, filename_prefix='ComfyUI', filename_delimiter='_',
                        filename_number_padding=4, file_extension='.txt', encoding='utf-8', filename_suffix=''):
         tokens = TextTokens()
         path = tokens.parseTokens(path)
+        # Make relative paths stable by anchoring them to ComfyUI's output dir
+        # instead of the process CWD (which varies based on how ComfyUI is launched).
+        if not os.path.isabs(path):
+            path = os.path.abspath(os.path.join(comfy_paths.output_directory, path.lstrip("./\\")))
         filename_prefix = tokens.parseTokens(filename_prefix)
 
         if not os.path.exists(path):


### PR DESCRIPTION
This fixes a CWD-dependent path bug in WAS_Text_Save.save_text_file.

Currently, if the path input is relative (e.g. ./ComfyUI/output/[time(...)]), it’s interpreted relative to the process working directory, which varies depending on how ComfyUI is launched (conda run, portable build, service, etc.). On Windows this can resolve somewhere unwritable (e.g. trying to create C:\ComfyUI\...), leading to Access is denied / FileNotFoundError when listing the directory for filename numbering.

Change:
- If path is not absolute, resolve it as os.path.abspath(os.path.join(folder_paths.output_directory, path.lstrip("./\\"))).

Result:
- Relative paths are stable and consistent with ComfyUI’s output root, avoiding CWD surprises and permission errors.