### PR TITLE
fix: return tuple from WAS_CLIP_Vision_Input_Switch on False branch

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -13693,7 +13693,7 @@ class WAS_CLIP_Vision_Input_Switch:
         if boolean:
             return (clip_vision_a, )
         else:
-            return (clip_vision_b)
+            return (clip_vision_b,)
 
 # TEXT INPUT SWITCH
 


### PR DESCRIPTION
## Summary

`WAS_CLIP_Vision_Input_Switch.clip_vision_switch` returns `(clip_vision_b)` on the `else` branch (line 13696) — that's a grouped expression, not a single-element tuple. ComfyUI's executor stores node outputs and indexes them by `RETURN_TYPES` slot, so downstream consumers receive the bare `ClipVisionModel` object instead of `(ClipVisionModel,)`. Any node that reads slot 0 (e.g. `CLIPVisionEncode`) then errors.

```python
def clip_vision_switch(self, clip_vision_a, clip_vision_b, boolean=True):
    if boolean:
        return (clip_vision_a, )      # tuple — correct
    else:
        return (clip_vision_b)        # NOT a tuple — bug
```

Sibling switches in the same file (`WAS_Text_Input_Switch`, `WAS_Image_Input_Switch`, etc.) all use the trailing comma, so this is a one-character typo in a single branch.

## Repro

Any Flux Redux–style workflow that wires a `BOOLEAN` set to `false` into `CLIP Vision Input Switch` and feeds its output into `CLIPVisionEncode` reliably fails. Swapping in core's `ComfySwitchNode` makes the same workflow run, confirming the failure is internal to the WAS node. Repro workflow: the Flux Redux model example.

## Fix

Add the trailing comma so the else branch returns `(clip_vision_b,)`. One character.