### PR TITLE
feat/fix: Implement robust JPEG EXIF embedding and frontend drag-and-drop parser

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -7470,6 +7470,10 @@ class WAS_Image_Save:
                     except Exception:
                         pass
                 exif_data = img_exif.tobytes()
+                
+                if extension in ['jpg', 'jpeg'] and len(exif_data) > 65533:
+                    cstr(f"Warning: Workflow EXIF data is too large ({len(exif_data)} bytes) for JPEG format. Saving without workflow metadata. Use PNG or WebP for large workflows.").warning.print()
+                    exif_data = b""
             else:
                 metadata = PngInfo()
                 if embed_workflow == 'true':

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -7461,27 +7461,10 @@ class WAS_Image_Save:
                         for x in extra_pnginfo:
                             workflow_metadata += json.dumps(extra_pnginfo[x])
                     img_exif[0x010e] = "Workflow:" + workflow_metadata
-                    
-                    try:
-                        import PIL.ExifTags
-                        exif_ifd = img_exif.get_ifd(PIL.ExifTags.IFD.Exif)
-                        user_comment = "Workflow:" + workflow_metadata + "\nPrompt:" + prompt_str
-                        exif_ifd[0x9286] = b'UNICODE\x00' + user_comment.encode('utf-16le')
-                    except Exception:
-                        pass
+                
                 exif_data = img_exif.tobytes()
                 
                 if extension in ['jpg', 'jpeg'] and len(exif_data) > 65533:
-                    try:
-                        import PIL.ExifTags
-                        exif_ifd = img_exif.get_ifd(PIL.ExifTags.IFD.Exif)
-                        if 0x9286 in exif_ifd:
-                            del exif_ifd[0x9286]
-                        exif_data = img_exif.tobytes()
-                    except Exception:
-                        pass
-                        
-                    if len(exif_data) > 65533:
                         cstr(f"Warning: Workflow EXIF data is too large ({len(exif_data)} bytes) for JPEG format. Saving without workflow metadata. Use PNG or WebP for large workflows.").warning.print()
                         exif_data = b""
             else:

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -7461,11 +7461,18 @@ class WAS_Image_Save:
                         for x in extra_pnginfo:
                             workflow_metadata += json.dumps(extra_pnginfo[x])
                     img_exif[0x010e] = "Workflow:" + workflow_metadata
-                
                 exif_data = img_exif.tobytes()
                 
                 if extension in ['jpg', 'jpeg'] and len(exif_data) > 65533:
-                        cstr(f"Warning: Workflow EXIF data is too large ({len(exif_data)} bytes) for JPEG format. Saving without workflow metadata. Use PNG or WebP for large workflows.").warning.print()
+                    if 0x010e in img_exif:
+                        del img_exif[0x010e]
+                        try:
+                            exif_data = img_exif.tobytes()
+                        except Exception:
+                            pass
+                            
+                    if len(exif_data) > 65533:
+                        cstr(f"Warning: Prompt EXIF data is too large ({len(exif_data)} bytes) for JPEG format. Saving without metadata. Use PNG or WebP for large workflows.").warning.print()
                         exif_data = b""
             else:
                 metadata = PngInfo()

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -7472,8 +7472,18 @@ class WAS_Image_Save:
                 exif_data = img_exif.tobytes()
                 
                 if extension in ['jpg', 'jpeg'] and len(exif_data) > 65533:
-                    cstr(f"Warning: Workflow EXIF data is too large ({len(exif_data)} bytes) for JPEG format. Saving without workflow metadata. Use PNG or WebP for large workflows.").warning.print()
-                    exif_data = b""
+                    try:
+                        import PIL.ExifTags
+                        exif_ifd = img_exif.get_ifd(PIL.ExifTags.IFD.Exif)
+                        if 0x9286 in exif_ifd:
+                            del exif_ifd[0x9286]
+                        exif_data = img_exif.tobytes()
+                    except Exception:
+                        pass
+                        
+                    if len(exif_data) > 65533:
+                        cstr(f"Warning: Workflow EXIF data is too large ({len(exif_data)} bytes) for JPEG format. Saving without workflow metadata. Use PNG or WebP for large workflows.").warning.print()
+                        exif_data = b""
             else:
                 metadata = PngInfo()
                 if embed_workflow == 'true':

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -7449,7 +7449,7 @@ class WAS_Image_Save:
             img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
 
             # Delegate metadata/pnginfo
-            if extension == 'webp':
+            if extension in ['webp', 'jpg', 'jpeg']:
                 img_exif = img.getexif()
                 if embed_workflow == 'true':
                     workflow_metadata = ''
@@ -7461,6 +7461,14 @@ class WAS_Image_Save:
                         for x in extra_pnginfo:
                             workflow_metadata += json.dumps(extra_pnginfo[x])
                     img_exif[0x010e] = "Workflow:" + workflow_metadata
+                    
+                    try:
+                        import PIL.ExifTags
+                        exif_ifd = img_exif.get_ifd(PIL.ExifTags.IFD.Exif)
+                        user_comment = "Workflow:" + workflow_metadata + "\nPrompt:" + prompt_str
+                        exif_ifd[0x9286] = b'UNICODE\x00' + user_comment.encode('utf-16le')
+                    except Exception:
+                        pass
                 exif_data = img_exif.tobytes()
             else:
                 metadata = PngInfo()
@@ -7488,7 +7496,7 @@ class WAS_Image_Save:
                 output_file = os.path.abspath(os.path.join(output_path, file))
                 if extension in ["jpg", "jpeg"]:
                     img.save(output_file,
-                             quality=quality, optimize=optimize_image, dpi=(dpi, dpi))
+                             quality=quality, optimize=optimize_image, dpi=(dpi, dpi), exif=exif_data)
                 elif extension == 'webp':
                     img.save(output_file,
                              quality=quality, lossless=lossless_webp, exif=exif_data)

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,5 @@
 from .WAS_Node_Suite import NODE_CLASS_MAPPINGS
 
-__all__ = ['NODE_CLASS_MAPPINGS']
+WEB_DIRECTORY = "./js"
+
+__all__ = ['NODE_CLASS_MAPPINGS', 'WEB_DIRECTORY']

--- a/js/was_jpeg_metadata.js
+++ b/js/was_jpeg_metadata.js
@@ -1,0 +1,71 @@
+import { app } from "../../scripts/app.js";
+
+app.registerExtension({
+	name: "WAS_Node_Suite.JpegMetadata",
+	async setup(app) {
+		const originalHandleFile = app.handleFile;
+		app.handleFile = async function(file, ...args) {
+			if (file && (file.type === "image/jpeg" || file.name.toLowerCase().endsWith(".jpg") || file.name.toLowerCase().endsWith(".jpeg"))) {
+				try {
+					const arrayBuffer = await file.arrayBuffer();
+					const dataView = new DataView(arrayBuffer);
+					
+					if (dataView.getUint16(0) === 0xFFD8) {
+						let offset = 2;
+						while (offset < dataView.byteLength) {
+							const marker = dataView.getUint16(offset);
+							const length = dataView.getUint16(offset + 2);
+							
+							if (marker === 0xFFE1) {
+								const header = String.fromCharCode(...new Uint8Array(arrayBuffer, offset + 4, 6));
+								if (header === "Exif\0\0") {
+									const tiffOffset = offset + 10;
+									const littleEndian = dataView.getUint16(tiffOffset) === 0x4949; // "II"
+									
+									const readUint16 = (off) => dataView.getUint16(off, littleEndian);
+									const readUint32 = (off) => dataView.getUint32(off, littleEndian);
+									
+									const ifdOffset = readUint32(tiffOffset + 4);
+									const ifdStart = tiffOffset + ifdOffset;
+									
+									const numTags = readUint16(ifdStart);
+									let workflow = null;
+									let prompt = null;
+									
+									for (let i = 0; i < numTags; i++) {
+										const tagStart = ifdStart + 2 + (i * 12);
+										const tagId = readUint16(tagStart);
+										const tagCount = readUint32(tagStart + 4);
+										
+										if (tagId === 0x010E || tagId === 0x010F) {
+											const valueOffset = tagCount > 4 ? readUint32(tagStart + 8) : tagStart + 8;
+											const strBytes = new Uint8Array(arrayBuffer, tiffOffset + valueOffset, tagCount - 1);
+											const strValue = new TextDecoder("utf-8").decode(strBytes);
+											
+											if (strValue.startsWith("Workflow:")) {
+												workflow = strValue.substring(9);
+											} else if (strValue.startsWith("Prompt:")) {
+												prompt = strValue.substring(7);
+											}
+										}
+									}
+									
+									if (workflow) {
+										await app.loadGraphData(JSON.parse(workflow));
+									} else if (prompt) {
+										await app.loadApiJson(JSON.parse(prompt));
+									}
+									break;
+								}
+							}
+							offset += length + 2;
+						}
+					}
+				} catch (e) {
+					console.error("WAS Node Suite: Error parsing JPEG EXIF for workflow", e);
+				}
+			}
+			return await originalHandleFile.apply(this, [file, ...args]);
+		};
+	}
+});


### PR DESCRIPTION
This PR significantly improves how `WAS_Image_Save` handles JPEG format images by successfully embedding workflow metadata and extending ComfyUI's native frontend to parse JPEGs upon drag-and-drop. 

### Changes & Design Decisions

1. **Native JPEG EXIF Support in `WAS_Image_Save`:**
   - Modified `img.save()` to bundle EXIF data natively for JPEGs instead of throwing exceptions.
   - We utilize the standard `0x010E` (ImageDescription) and `0x010F` (Make) tags to safely pack the UI Workflow and API Prompt metadata.
   - **Decision:** We actively dropped A1111 compatibility (the `UserComment` tag) because it functionally duplicates the workflow metadata and wastes half of the JPEG metadata budget.

2. **64KB Safety Fallback for Massive Workflows:**
   - JPEGs have a strict, hard-coded 64KB limit for `APP1` EXIF chunks. Massive workflows would previously cause `PIL` to throw a `ValueError: EXIF data is too long` and fail to save the image entirely.
   - **Decision:** Implemented a size check before saving JPEGs. If the payload exceeds 64KB, it surgically strips the heavy UI Workflow metadata and falls back to only storing the API Prompt logic. If even the API logic exceeds 64KB, it suppresses the metadata entirely and prints a clean console warning, guaranteeing the image will always save successfully.

3. **New Frontend JPEG Metadata Parser (`was_jpeg_metadata.js`):**
   - ComfyUI's core frontend natively lacks any EXIF extractors for JPEGs. 
   - **Decision:** Created a lightweight TIFF IFD parser that hooks natively into `app.handleFile` via standard extension registration (`WEB_DIRECTORY = "./js"`). When a user drops a JPEG onto the canvas, this script parses the binary headers, locates the tags, and seamlessly passes the JSON payload directly into `app.loadGraphData()`, bridging the gap and making JPEG drag-and-drop identical to PNGs.
   
Manally tested by generating an image saved by "Save Image" node with 
 - extension: 4
 - embed_workflow: true
 Then drag and drop the generated jpg to ComgyUI. The workflow correctly populates. 

Example workflow embedded jpg:
<img width="1200" height="1600" alt="ComfyUI_0274" src="https://github.com/user-attachments/assets/c0e40b52-f667-420f-a54e-62593046eb6c" />
